### PR TITLE
Use elastic if no concurrentConnection is set in the request

### DIFF
--- a/cluster-executor/src/request_providers.rs
+++ b/cluster-executor/src/request_providers.rs
@@ -284,7 +284,7 @@ pub(crate) mod test {
     use datagen::data_schema_from_value;
     use datagen::template::build_engine;
     use http::Method;
-    use overload_http::{ConstantRate, Linear, Scheme, Steps, Target};
+    use overload_http::{ConstantRate, Elastic, Linear, Scheme, Steps, Target};
     use regex::Regex;
     use serde_json::{json, Value};
     use std::collections::HashMap;
@@ -417,7 +417,7 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            None,
+            Box::<Elastic>::default(),
             None,
         );
         let ret = generator.next().await;
@@ -444,7 +444,7 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            None,
+            Box::<Elastic>::default(),
             None,
         );
         let ret = generator.next().await;
@@ -470,7 +470,7 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            None,
+            Box::<Elastic>::default(),
             None,
         );
         let ret = generator.next().await;
@@ -493,7 +493,7 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            None,
+            Box::<Elastic>::default(),
             None,
         );
         let ret = generator.next().await;
@@ -517,7 +517,7 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            None,
+            Box::<Elastic>::default(),
             None,
         );
         let arg = generator.next().await.unwrap();
@@ -552,11 +552,11 @@ pub(crate) mod test {
                 port: 8080,
                 protocol: Scheme::HTTP,
             },
-            Some(Box::new(Linear {
+            Box::new(Linear {
                 a: 0.5,
                 b: 1,
                 max: 10,
-            })),
+            }),
             None,
         );
         let arg = generator.next().await.unwrap();

--- a/cluster-executor/src/secondary.rs
+++ b/cluster-executor/src/secondary.rs
@@ -93,7 +93,7 @@ impl LoadGenerationLogic for LoadGenerationMode {
             LoadGenerationMode::Batch { .. } => {
                 unimplemented!()
             }
-            LoadGenerationMode::Immediate => 65535,
+            LoadGenerationMode::Immediate => u16::MAX as usize,
         }
     }
 
@@ -182,7 +182,7 @@ async fn handle_connection_from_primary(
 
     let elastic_pool = matches!(
         request.concurrent_connection,
-        Some(ConcurrentConnectionRateSpec::Elastic(_))
+        ConcurrentConnectionRateSpec::Elastic(_)
     );
     let buckets = request.histogram_buckets.clone();
     let metrics = metrics_factory
@@ -327,7 +327,7 @@ async fn handle_connection_from_primary_v2(
 
     let elastic_pool = matches!(
         request.concurrent_connection,
-        Some(ConcurrentConnectionRateSpec::Elastic(_))
+        ConcurrentConnectionRateSpec::Elastic(_)
     );
 
     let buckets = request.histogram_buckets.clone();
@@ -538,7 +538,10 @@ async fn get_new_queue_pool(
     keep_alive: ConnectionKeepAlive,
     elastic_pool: bool,
 ) -> QueuePool {
-    debug!("Creating new pool for: {}", &host_port);
+    debug!(
+        "Creating new pool for: {}, elastic: {elastic_pool}",
+        &host_port
+    );
     QueuePool::new(host_port, keep_alive, elastic_pool)
 }
 

--- a/overload-http/src/lib.rs
+++ b/overload-http/src/lib.rs
@@ -142,7 +142,7 @@ pub struct Request {
     pub target: Target,
     pub req: RequestSpecEnum,
     pub qps: RateSpecEnum,
-    pub concurrent_connection: Option<ConcurrentConnectionRateSpec>,
+    pub concurrent_connection: ConcurrentConnectionRateSpec,
     pub connection_keep_alive: ConnectionKeepAlive,
     pub histogram_buckets: SmallVec<[f64; 6]>,
     pub response_assertion: Option<ResponseAssertion>,
@@ -157,7 +157,8 @@ pub struct RequestShadow {
     pub target: Target,
     pub req: RequestSpecEnum,
     pub qps: RateSpecEnum,
-    pub concurrent_connection: Option<ConcurrentConnectionRateSpec>,
+    #[serde(default = "default_concurrent_connection")]
+    pub concurrent_connection: ConcurrentConnectionRateSpec,
     #[serde(default)]
     pub connection_keep_alive: ConnectionKeepAlive,
     #[serde(default = "default_histogram_bucket")]
@@ -381,6 +382,10 @@ pub fn default_histogram_bucket() -> SmallVec<[f64; 6]> {
 
 pub fn default_generation_mode() -> LoadGenerationMode {
     LoadGenerationMode::Immediate
+}
+
+pub fn default_concurrent_connection() -> ConcurrentConnectionRateSpec {
+    ConcurrentConnectionRateSpec::Elastic(Elastic::default())
 }
 
 fn uuid() -> String {

--- a/overload-http/src/rate_spec.rs
+++ b/overload-http/src/rate_spec.rs
@@ -30,9 +30,17 @@ impl Default for Bounded {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Elastic {
-    max: u32,
+    pub(crate) max: u32,
+}
+
+impl Default for Elastic {
+    fn default() -> Self {
+        Self {
+            max: u16::MAX as u32,
+        }
+    }
 }
 
 /// Increase QPS linearly as per equation


### PR DESCRIPTION
Fixes a bug where immediate mode doesn't create any connection when no concurrentConnection is provided